### PR TITLE
fix: charset=UTF-8

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="description" content="#@description" />
     <base href="/breaklock/" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
     <link rel="shortcut icon" href="assets/favicon.ico" />
     <meta name="theme-color" content="#14171b" />


### PR DESCRIPTION
There is an issue that arises when the game is installed via a CDN and the Content-Type header does not contain the UTF-8 character encoding:
<img width="152" alt="image" src="https://user-images.githubusercontent.com/57063378/232246502-d5d42e56-69b8-414d-9d46-7a23a7577589.png">
